### PR TITLE
Fix for the Build GH Check Fails

### DIFF
--- a/.github/workflows/create-build-zip.yml
+++ b/.github/workflows/create-build-zip.yml
@@ -15,7 +15,11 @@ jobs:
       git-sha-8: ${{ steps.retrieve-git-sha-8.outputs.sha8 }}
     steps:
       - name: Check out source files
-        uses: actions/checkout@v2
+      - uses: actions/checkout@master
+      - name: Setup node 14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |

--- a/.github/workflows/create-build-zip.yml
+++ b/.github/workflows/create-build-zip.yml
@@ -14,7 +14,6 @@ jobs:
       branch-name: ${{ steps.retrieve-branch-name.outputs.branch_name }}
       git-sha-8: ${{ steps.retrieve-git-sha-8.outputs.sha8 }}
     steps:
-      - name: Check out source files
       - uses: actions/checkout@master
       - name: Setup node 14
         uses: actions/setup-node@v1


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Build GH check was failing, as I see that's fixed on https://github.com/Codeinwp/raft/pull/30 by @HardeepAsrani 

Here, I've cherry-picks his commits to be able to merge development and didn't fix any specific to don't cause PR conflicts.

Commits:
* https://github.com/Codeinwp/raft/pull/30/commits/69aa954829e358a163984120228a2c566eb88aba
* https://github.com/Codeinwp/raft/pull/30/commits/df9d44763a973c2f44e653db8387157f00313d22

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots 
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
N/A

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/themeisle/issues/1445
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->