### PR TITLE
feat: use spacing variables

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -187,9 +187,9 @@
 			},
 			"spacingSizes": [
 				{
-					"name": "2XS",
+					"name": "XXS",
 					"size": "clamp(.4rem, 2vw, 0.5rem)",
-					"slug": "2xs"
+					"slug": "xxs"
 				},
 				{
 					"name": "XS",
@@ -217,9 +217,9 @@
 					"slug": "xl"
 				},
 				{
-					"name": "2XL",
+					"name": "XXL",
 					"size": "clamp(3rem, 7vw, 5rem)",
-					"slug": "2xl"
+					"slug": "xxl"
 				}
 			],
 			"units": [

--- a/theme.json
+++ b/theme.json
@@ -1,422 +1,460 @@
 {
-  "version": 2,
-  "settings": {
-    "appearanceTools": true,
-    "color": {
-      "palette": [
-        {
-          "slug": "raft-bg",
-          "color": "#EBE8E6",
-          "name": "Background"
-        },
-        {
-          "slug": "raft-fg",
-          "color": "#1D1F25",
-          "name": "Foreground"
-        },
-        {
-          "slug": "raft-bg-alt",
-          "color": "rgba(255, 255, 255, 0.6)",
-          "name": "Background Alt"
-        },
-        {
-          "slug": "raft-fg-alt",
-          "color": "#FDFDFD",
-          "name": "Foreground Alt"
-        },
-        {
-          "slug": "raft-accent",
-          "color": "#C26148",
-          "name": "Accent"
-        }
-      ],
-      "link": true,
-      "gradients": []
-    },
-    "typography": {
-      "lineHeight": true,
-      "customFontSize": true,
-      "fontFamilies": [
-        {
-          "fontFace": [
-            {
-              "fontDisplay": "swap",
-              "fontFamily": "Readex Pro",
-              "fontStretch": "normal",
-              "fontStyle": "normal",
-              "fontWeight": "160 700",
-              "src": [
-                "file:./assets/fonts/readex-pro/ReadexPro-VariableFont_wght.ttf"
-              ]
-            }
-          ],
-          "fontFamily": "\"Readex Pro\", sans-serif",
-          "name": "Readex Pro",
-          "slug": "body"
-        },
-        {
-          "fontFace": [
-            {
-              "fontFamily": "Source Serif Pro",
-              "fontStretch": "normal",
-              "fontStyle": "normal",
-              "fontWeight": "200 900",
-              "src": [
-                "file:./assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2"
-              ]
-            },
-            {
-              "fontFamily": "Source Serif Pro",
-              "fontStretch": "normal",
-              "fontStyle": "italic",
-              "fontWeight": "200 900",
-              "src": [
-                "file:./assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2"
-              ]
-            }
-          ],
-          "fontFamily": "\"Source Serif Pro\", serif",
-          "name": "Source Serif Pro",
-          "slug": "source-serif-pro"
-        },
-        {
-          "fontFace": [
-            {
-              "fontFamily": "Figtree",
-              "fontStretch": "normal",
-              "fontStyle": "normal",
-              "fontWeight": "300 900",
-              "src": [
-                "file:./assets/fonts/figtree/Figtree-VariableFont_wght.ttf"
-              ]
-            },
-            {
-              "fontFamily": "Figtree",
-              "fontStretch": "normal",
-              "fontStyle": "italic",
-              "fontWeight": "300 900",
-              "src": [
-                "file:./assets/fonts/figtree/Figtree-Italic-VariableFont_wght.ttf"
-              ]
-            }
-          ],
-          "fontFamily": "\"Figtree\", sans-serif",
-          "name": "Figtree",
-          "slug": "figtree"
-        },
-        {
-          "fontFace": [
-            {
-              "fontDisplay": "swap",
-              "fontFamily": "Outfit",
-              "fontStretch": "normal",
-              "fontStyle": "normal",
-              "fontWeight": "100 900",
-              "src": [
-                "file:./assets/fonts/outfit/Outfit-VariableFont_wght.ttf"
-              ]
-            }
-          ],
-          "fontFamily": "\"Outfit\", sans-serif",
-          "name": "Outfit",
-          "slug": "outfit"
-        },
-        {
-          "fontFace": [
-            {
-              "fontFamily": "Lora",
-              "fontStretch": "normal",
-              "fontStyle": "normal",
-              "fontWeight": "400 700",
-              "src": [
-                "file:./assets/fonts/lora/Lora-VariableFont_wght.ttf"
-              ]
-            },
-            {
-              "fontFamily": "Lora",
-              "fontStretch": "normal",
-              "fontStyle": "italic",
-              "fontWeight": "400 700",
-              "src": [
-                "file:./assets/fonts/lora/Lora-Italic-VariableFont_wght.ttf"
-              ]
-            }
-          ],
-          "fontFamily": "\"Lora\", serif",
-          "name": "Lora",
-          "slug": "lora"
-        }
-      ],
-      "fontSizes": [
-        {
-          "slug": "small",
-          "size": "14px",
-          "name": "Small"
-        },
-        {
-          "slug": "normal",
-          "size": "18px",
-          "name": "Normal"
-        },
-        {
-          "slug": "medium",
-          "size": "24px",
-          "name": "Medium"
-        },
-        {
-          "slug": "large",
-          "size": "28px",
-          "name": "Large"
-        },
-        {
-          "slug": "x-large",
-          "size": "32px",
-          "name": "Extra Large"
-        },
-        {
-          "slug": "huge",
-          "size": "56px",
-          "name": "Huge"
-        }
-      ]
-    },
-    "spacing": {
-      "blockGap": true,
-      "margin": true,
-      "padding": true,
-      "units": [
-        "px",
-        "em",
-        "rem",
-        "vh",
-        "vw",
-        "%"
-      ]
-    },
-    "layout": {
-      "contentSize": "740px",
-      "wideSize": "960px"
-    },
-    "border": {
-      "color": true,
-      "radius": true,
-      "style": true,
-      "width": true
-    },
-    "custom": {
-      "spacing": {
-        "baseline": "16px",
-        "small": "min(24px, 6.4vw)",
-        "gap": {
-          "horizontal": "clamp( calc( 1.5 * var( --wp--custom--spacing--baseline ) ), 2.222vw, calc( 2 * var( --wp--custom--spacing--baseline ) ) )",
-          "vertical": "clamp( calc( 1.5 * var( --wp--custom--spacing--baseline ) ), 3.333vw, calc( 3 * var( --wp--custom--spacing--baseline ) ) )"
-        },
-        "gutter": "clamp( calc( 1.5 * var( --wp--custom--spacing--baseline ) ), 3.333vw, calc( 3 * var( --wp--custom--spacing--baseline ) ) )",
-        "outer": "var( --wp--custom--spacing--gutter )"
-      },
-      "typography": {
-        "fontSmoothing": {
-          "moz": "grayscale",
-          "webkit": "antialiased"
-        }
-      }
-    }
-  },
-  "styles": {
-    "color": {
-      "background": "var(--wp--preset--color--raft-bg)",
-      "text": "var(--wp--preset--color--raft-fg)"
-    },
-    "typography": {
-      "fontSize": "var(--wp--preset--font-size--normal)",
-      "fontFamily": "var(--wp--preset--font-family--body)",
-      "fontWeight": "400",
-      "lineHeight": "1.7"
-    },
-    "elements": {
-      "link": {
-        "color": {
-          "text": "var(--wp--preset--color--raft-fg)"
-        },
-        "typography": {
-          "textDecoration": "none"
-        }
-      },
-      "h1": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--huge)",
-          "fontWeight": "600",
-          "lineHeight": "1.25"
-        }
-      },
-      "h2": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--x-large)",
-          "fontWeight": "600",
-          "lineHeight": "1.35"
-        }
-      },
-      "h3": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--large)",
-          "fontWeight": "600",
-          "lineHeight": "1.35"
-        }
-      },
-      "h4": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--medium)",
-          "fontWeight": "600",
-          "lineHeight": "1.4"
-        }
-      },
-      "h5": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--normal)",
-          "fontWeight": "600",
-          "lineHeight": "1.55"
-        }
-      },
-      "h6": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--small)",
-          "fontWeight": "600",
-          "lineHeight": "1.6"
-        }
-      }
-    },
-    "blocks": {
-      "core/button": {
-        "border": {
-          "radius": "3px"
-        },
-        "color": {
-          "background": "var(--wp--preset--color--raft-accent)",
-          "text": "var(--wp--preset--color--raft-fg-alt)"
-        },
-        "spacing": {
-          "padding": {
-            "bottom": "16px",
-            "left": "32px",
-            "right": "32px",
-            "top": "16px"
-          }
-        },
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--normal)",
-          "fontWeight": "600"
-        }
-      },
-      "core/comment-content": {
-        "border": {
-          "radius": "5px"
-        },
-        "color": {
-          "background": "var(--wp--preset--color--raft-bg-alt)"
-        },
-        "spacing": {
-          "padding": {
-            "bottom": "24px",
-            "left": "24px",
-            "right": "24px",
-            "top": "24px"
-          }
-        }
-      },
-      "core/comment-author-name": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--normal)"
-        }
-      },
-      "core/comment-date": {
-        "typography": {
-          "textTransform": "uppercase",
-          "fontSize": "12px"
-        }
-      },
-      "core/comment-edit-link": {
-        "typography": {
-          "textTransform": "uppercase",
-          "fontSize": "12px"
-        }
-      },
-      "core/comment-reply-link": {
-        "typography": {
-          "textTransform": "uppercase"
-        },
-        "elements": {
-          "link": {
-            "typography": {
-              "fontSize": "var(--wp--preset--font-size--small)"
-            },
-            "color": {
-              "text": "var(--wp--preset--color--raft-accent)"
-            }
-          }
-        }
-      },
-      "core/search": {
-        "border": {
-          "radius": "5px"
-        }
-      },
-      "core/quote": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--large)"
-        }
-      },
-      "woocommerce/mini-cart-contents": {
-        "color": {
-          "text": "var(--wp--preset--color--raft-fg)",
-          "background": "var(--wp--preset--color--raft-bg)"
-        },
-        "elements": {
-          "link": {
-            "color": {
-              "text": "var(--wp--preset--color--raft-accent)"
-            }
-          }
-        }
-      }
-    }
-  },
-  "customTemplates": [
-    {
-      "name": "template-blank",
-      "title": "Blank Page - Only Content"
-    },
-    {
-      "name": "single-product",
-      "title": "WooCommerce Single Product"
-    },
-    {
-      "name": "page-checkout",
-      "title": "WooCommerce Checkout"
-    },
-    {
-      "name": "page-cart",
-      "title": "WooCommerce Cart"
-    }
-  ],
-  "templateParts": [
-    {
-      "name": "header",
-      "title": "Header",
-      "area": "header"
-    },{
-      "name": "header-centered",
-      "title": "Header Centered",
-      "area": "header"
-    },
-    {
-      "name": "footer",
-      "title": "Footer",
-      "area": "footer"
-    },
-    {
-      "name": "footer-with-columns",
-      "title": "Footer with Columns",
-      "area": "footer"
-    }
-  ]
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"version": 2,
+	"settings": {
+		"appearanceTools": true,
+		"color": {
+			"palette": [
+				{
+					"slug": "raft-bg",
+					"color": "#EBE8E6",
+					"name": "Background"
+				},
+				{
+					"slug": "raft-fg",
+					"color": "#1D1F25",
+					"name": "Foreground"
+				},
+				{
+					"slug": "raft-bg-alt",
+					"color": "rgba(255, 255, 255, 0.6)",
+					"name": "Background Alt"
+				},
+				{
+					"slug": "raft-fg-alt",
+					"color": "#FDFDFD",
+					"name": "Foreground Alt"
+				},
+				{
+					"slug": "raft-accent",
+					"color": "#C26148",
+					"name": "Accent"
+				}
+			],
+			"link": true,
+			"gradients": []
+		},
+		"typography": {
+			"lineHeight": true,
+			"customFontSize": true,
+			"fontFamilies": [
+				{
+					"fontFace": [
+						{
+							"fontDisplay": "swap",
+							"fontFamily": "Readex Pro",
+							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "160 700",
+							"src": [
+								"file:./assets/fonts/readex-pro/ReadexPro-VariableFont_wght.ttf"
+							]
+						}
+					],
+					"fontFamily": "\"Readex Pro\", sans-serif",
+					"name": "Readex Pro",
+					"slug": "body"
+				},
+				{
+					"fontFace": [
+						{
+							"fontFamily": "Source Serif Pro",
+							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "200 900",
+							"src": [
+								"file:./assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2"
+							]
+						},
+						{
+							"fontFamily": "Source Serif Pro",
+							"fontStretch": "normal",
+							"fontStyle": "italic",
+							"fontWeight": "200 900",
+							"src": [
+								"file:./assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2"
+							]
+						}
+					],
+					"fontFamily": "\"Source Serif Pro\", serif",
+					"name": "Source Serif Pro",
+					"slug": "source-serif-pro"
+				},
+				{
+					"fontFace": [
+						{
+							"fontFamily": "Figtree",
+							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "300 900",
+							"src": [
+								"file:./assets/fonts/figtree/Figtree-VariableFont_wght.ttf"
+							]
+						},
+						{
+							"fontFamily": "Figtree",
+							"fontStretch": "normal",
+							"fontStyle": "italic",
+							"fontWeight": "300 900",
+							"src": [
+								"file:./assets/fonts/figtree/Figtree-Italic-VariableFont_wght.ttf"
+							]
+						}
+					],
+					"fontFamily": "\"Figtree\", sans-serif",
+					"name": "Figtree",
+					"slug": "figtree"
+				},
+				{
+					"fontFace": [
+						{
+							"fontDisplay": "swap",
+							"fontFamily": "Outfit",
+							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "100 900",
+							"src": [
+								"file:./assets/fonts/outfit/Outfit-VariableFont_wght.ttf"
+							]
+						}
+					],
+					"fontFamily": "\"Outfit\", sans-serif",
+					"name": "Outfit",
+					"slug": "outfit"
+				},
+				{
+					"fontFace": [
+						{
+							"fontFamily": "Lora",
+							"fontStretch": "normal",
+							"fontStyle": "normal",
+							"fontWeight": "400 700",
+							"src": [
+								"file:./assets/fonts/lora/Lora-VariableFont_wght.ttf"
+							]
+						},
+						{
+							"fontFamily": "Lora",
+							"fontStretch": "normal",
+							"fontStyle": "italic",
+							"fontWeight": "400 700",
+							"src": [
+								"file:./assets/fonts/lora/Lora-Italic-VariableFont_wght.ttf"
+							]
+						}
+					],
+					"fontFamily": "\"Lora\", serif",
+					"name": "Lora",
+					"slug": "lora"
+				}
+			],
+			"fontSizes": [
+				{
+					"slug": "small",
+					"size": "14px",
+					"name": "Small"
+				},
+				{
+					"slug": "normal",
+					"size": "18px",
+					"name": "Normal"
+				},
+				{
+					"slug": "medium",
+					"size": "24px",
+					"name": "Medium"
+				},
+				{
+					"slug": "large",
+					"size": "28px",
+					"name": "Large"
+				},
+				{
+					"slug": "x-large",
+					"size": "32px",
+					"name": "Extra Large"
+				},
+				{
+					"slug": "huge",
+					"size": "56px",
+					"name": "Huge"
+				}
+			]
+		},
+		"spacing": {
+			"spacingScale": {
+				"steps": 0
+			},
+			"spacingSizes": [
+				{
+					"name": "2XS",
+					"size": "clamp(.4rem, 2vw, 0.5rem)",
+					"slug": "2xs"
+				},
+				{
+					"name": "XS",
+					"size": "clamp(.6rem, 2.5vw, 1rem)",
+					"slug": "xs"
+				},
+				{
+					"name": "S",
+					"size": "clamp(1rem, 3vw, 1.5rem)",
+					"slug": "s"
+				},
+				{
+					"name": "M",
+					"size": "clamp(1.5rem, 4vw, 2rem)",
+					"slug": "m"
+				},
+				{
+					"name": "L",
+					"size": "clamp(2rem, 5vw, 3rem)",
+					"slug": "l"
+				},
+				{
+					"name": "XL",
+					"size": "clamp(3rem, 6vw, 4rem)",
+					"slug": "xl"
+				},
+				{
+					"name": "2XL",
+					"size": "clamp(3rem, 7vw, 5rem)",
+					"slug": "2xl"
+				}
+			],
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw",
+				"%"
+			]
+		},
+		"layout": {
+			"contentSize": "740px",
+			"wideSize": "960px"
+		},
+		"border": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true
+		},
+		"custom": {
+			"spacing": {
+				"baseline": "16px",
+				"small": "min(24px, 6.4vw)",
+				"gap": {
+					"horizontal": "clamp( calc( 1.5 * var( --wp--custom--spacing--baseline ) ), 2.222vw, calc( 2 * var( --wp--custom--spacing--baseline ) ) )",
+					"vertical": "clamp( calc( 1.5 * var( --wp--custom--spacing--baseline ) ), 3.333vw, calc( 3 * var( --wp--custom--spacing--baseline ) ) )"
+				},
+				"gutter": "clamp( calc( 1.5 * var( --wp--custom--spacing--baseline ) ), 3.333vw, calc( 3 * var( --wp--custom--spacing--baseline ) ) )",
+				"outer": "var( --wp--custom--spacing--gutter )"
+			},
+			"typography": {
+				"fontSmoothing": {
+					"moz": "grayscale",
+					"webkit": "antialiased"
+				}
+			}
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--raft-bg)",
+			"text": "var(--wp--preset--color--raft-fg)"
+		},
+		"typography": {
+			"fontSize": "var(--wp--preset--font-size--normal)",
+			"fontFamily": "var(--wp--preset--font-family--body)",
+			"fontWeight": "400",
+			"lineHeight": "1.7"
+		},
+		"elements": {
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--raft-fg)"
+				},
+				"typography": {
+					"textDecoration": "none"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--huge)",
+					"fontWeight": "600",
+					"lineHeight": "1.25"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)",
+					"fontWeight": "600",
+					"lineHeight": "1.35"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontWeight": "600",
+					"lineHeight": "1.35"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"fontWeight": "600",
+					"lineHeight": "1.4"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"fontWeight": "600",
+					"lineHeight": "1.55"
+				}
+			},
+			"h6": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "600",
+					"lineHeight": "1.6"
+				}
+			}
+		},
+		"blocks": {
+			"core/button": {
+				"border": {
+					"radius": "3px"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--raft-accent)",
+					"text": "var(--wp--preset--color--raft-fg-alt)"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "16px",
+						"left": "32px",
+						"right": "32px",
+						"top": "16px"
+					}
+				},
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"fontWeight": "600"
+				}
+			},
+			"core/comment-content": {
+				"border": {
+					"radius": "5px"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--raft-bg-alt)"
+				},
+				"spacing": {
+					"padding": {
+						"bottom": "24px",
+						"left": "24px",
+						"right": "24px",
+						"top": "24px"
+					}
+				}
+			},
+			"core/comment-author-name": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--normal)"
+				}
+			},
+			"core/comment-date": {
+				"typography": {
+					"textTransform": "uppercase",
+					"fontSize": "12px"
+				}
+			},
+			"core/comment-edit-link": {
+				"typography": {
+					"textTransform": "uppercase",
+					"fontSize": "12px"
+				}
+			},
+			"core/comment-reply-link": {
+				"typography": {
+					"textTransform": "uppercase"
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"fontSize": "var(--wp--preset--font-size--small)"
+						},
+						"color": {
+							"text": "var(--wp--preset--color--raft-accent)"
+						}
+					}
+				}
+			},
+			"core/search": {
+				"border": {
+					"radius": "5px"
+				}
+			},
+			"core/quote": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"woocommerce/mini-cart-contents": {
+				"color": {
+					"text": "var(--wp--preset--color--raft-fg)",
+					"background": "var(--wp--preset--color--raft-bg)"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--raft-accent)"
+						}
+					}
+				}
+			}
+		}
+	},
+	"customTemplates": [
+		{
+			"name": "template-blank",
+			"title": "Blank Page - Only Content"
+		},
+		{
+			"name": "single-product",
+			"title": "WooCommerce Single Product"
+		},
+		{
+			"name": "page-checkout",
+			"title": "WooCommerce Checkout"
+		},
+		{
+			"name": "page-cart",
+			"title": "WooCommerce Cart"
+		}
+	],
+	"templateParts": [
+		{
+			"name": "header",
+			"title": "Header",
+			"area": "header"
+		},{
+			"name": "header-centered",
+			"title": "Header Centered",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"title": "Footer",
+			"area": "footer"
+		},
+		{
+			"name": "footer-with-columns",
+			"title": "Footer with Columns",
+			"area": "footer"
+		}
+	]
 }

--- a/theme.json
+++ b/theme.json
@@ -189,37 +189,37 @@
 				{
 					"name": "XXS",
 					"size": "clamp(.4rem, 2vw, 0.5rem)",
-					"slug": "xxs"
+					"slug": "20"
 				},
 				{
 					"name": "XS",
 					"size": "clamp(.6rem, 2.5vw, 1rem)",
-					"slug": "xs"
+					"slug": "30"
 				},
 				{
 					"name": "S",
 					"size": "clamp(1rem, 3vw, 1.5rem)",
-					"slug": "s"
+					"slug": "40"
 				},
 				{
 					"name": "M",
 					"size": "clamp(1.5rem, 4vw, 2rem)",
-					"slug": "m"
+					"slug": "50"
 				},
 				{
 					"name": "L",
 					"size": "clamp(2rem, 5vw, 3rem)",
-					"slug": "l"
+					"slug": "60"
 				},
 				{
 					"name": "XL",
 					"size": "clamp(3rem, 6vw, 4rem)",
-					"slug": "xl"
+					"slug": "70"
 				},
 				{
 					"name": "XXL",
 					"size": "clamp(3rem, 7vw, 5rem)",
-					"slug": "xxl"
+					"slug": "80"
 				}
 			],
 			"units": [


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

It makes use of new spacing variables instead of using pixels. This PR also formats the theme.json file, hence the long diff. In hindsight, I should've used multiple commits but the diff viewer in VSCode didn't prepare me for Github. 😄 

Only changes to the code were made here:

Before: https://github.com/Codeinwp/raft/pull/67/files#diff-160c735a986cf8c05e1f6b2e9ac89dd0410562d2fe5ccbdc93157bd92f3dc2bcL183-L186

After: https://github.com/Codeinwp/raft/pull/67/files#diff-160c735a986cf8c05e1f6b2e9ac89dd0410562d2fe5ccbdc93157bd92f3dc2bcR184-R224

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
No

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure the spacing is consistent when switching from an old version of Raft to new version.
- Existing sites shouldn't behave any differently from what they were already doing.
- When making new pages and using Spacing settings, the spacing should be using the new spacing classes & values.

<!-- Issues that this pull request closes. -->
Closes #66.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->