### PR TITLE
feat: page template with only header & footer

### DIFF
--- a/templates/template-plain.html
+++ b/templates/template-plain.html
@@ -1,0 +1,7 @@
+<!-- wp:template-part {"slug":"header","theme":"raft","tagName":"header"} /-->
+
+<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"blockGap":"0"}},"layout":{"inherit":false}} -->
+<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:post-content {"layout":{"type":"constrained","contentSize":"100%"}} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"raft","tagName":"footer"} /-->

--- a/theme.json
+++ b/theme.json
@@ -511,6 +511,10 @@
 			"title": "Blank Page - Only Content"
 		},
 		{
+		  "name": "template-plain",
+		  "title": "Page with Header & Footer"
+		},
+		{
 			"name": "single-product",
 			"title": "WooCommerce Single Product"
 		},
@@ -528,7 +532,8 @@
 			"name": "header",
 			"title": "Header",
 			"area": "header"
-		},{
+		},
+		{
 			"name": "header-centered",
 			"title": "Header Centered",
 			"area": "header"


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
This adds a new page template with only Header & Footer, without the Page title as before.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a new page with this template.
- Make sure it loads nicely, works as expected.

<!-- Issues that this pull request closes. -->
Closes #79.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->