### PR TITLE
defines outline button styles in theme.json

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -416,7 +416,7 @@
 				        "radius": "3px",
 				        "style": "solid",
 				        "width": "2px",
-				        "color": "var(--wp--preset--color--raft-accent)"
+				        "color": "transparent"
 				    },
 				    "color": {
 				        "background": "var(--wp--preset--color--raft-accent)",
@@ -439,11 +439,11 @@
 				            "border": {
 				                "style": "solid",
 				                "width": "2px",
-				                "color": "var(--wp--preset--color--raft-accent)"
+				                "color": "inherit"
 				            },
 				            "color": {
 				                "background": "transparent",
-				                "text": "var(--wp--preset--color--raft-accent)"
+				                "text": "inherit"
 				            },
 				            "spacing": {
 				                "padding": {


### PR DESCRIPTION
### Summary
Adds style definitions for the outline button variation in theme.json
This addresses an old issue where the padding for the outline style was overriden by core.

Resources:
https://fullsiteediting.com/lessons/modifying-block-style-variations-via-theme-json/

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES. Both buttons should be consistent in size.

### Screenshots 

![Screenshot 2023-12-07 at 1 07 47 PM](https://github.com/Codeinwp/raft/assets/4193672/e3dd6ac0-63a2-4f94-8531-46bb5aeea978)

### Test instructions
Try to insert buttons, switch between default and outline, and see if the styles are consistent in terms of size.
Please double-check indentation and format. ✌🏻 

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->