### PR TITLE
feat: move caption color and font to theme.json

### DIFF
--- a/assets/css/src/blocks/_image.scss
+++ b/assets/css/src/blocks/_image.scss
@@ -1,8 +1,3 @@
-%figcaption {
-	text-align: left;
-	font-size: var(--wp--preset--font-size--small);
-}
-
 .wp-block-image {
 
 	&.aligncenter {
@@ -26,9 +21,7 @@
 figure.wp-block-image {
 
 	figcaption {
-
-		@extend %figcaption;
-		color: var(--wp--preset--color--raft-fg);
+		text-align: left;
 		opacity: 0.6;
 	}
 }
@@ -39,8 +32,7 @@ figure.wp-block-image {
 	figure.wp-block-image {
 
 		figcaption {
-
-			@extend %figcaption;
+			text-align: left;
 			background: rgba(0, 0, 0, 0.3);
 			margin: 0;
 			padding: 8px;

--- a/assets/css/src/blocks/_table.scss
+++ b/assets/css/src/blocks/_table.scss
@@ -13,8 +13,6 @@
 	}
 
 	figcaption {
-		font-size: var(--wp--preset--font-size--small);
-		color: var(--wp--preset--color--raft-fg);
 		opacity: 0.6;
 	}
 }

--- a/theme.json
+++ b/theme.json
@@ -408,6 +408,14 @@
 					"fontWeight": "600",
 					"lineHeight": "1.6"
 				}
+			},
+			"caption": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--raft-fg)"
+				}
 			}
 		},
 		"blocks": {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

This PR moves the Color & Typography to theme.json to avoid it overriding Site Editor preferences.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots 
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add an Image or Table with the caption
- Make sure the color changes if you change it to the sidebar.

<!-- Issues that this pull request closes. -->
Closes #56.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->