### PR TITLE
fix: nps survery appearing on new installs

### DIFF
--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -321,7 +321,7 @@ class Admin {
 				'apiHost'       => 'https://app.formbricks.com',
 				'userId'        => 'raft_' . $website_url,
 				'attributes'    => array(
-					'days_since_install' => self::convert_to_category( round( ( time() - get_option( 'raft_install', 0 ) ) / DAY_IN_SECONDS ) ),
+					'days_since_install' => self::convert_to_category( round( ( time() - get_option( 'raft_install', time() ) ) / DAY_IN_SECONDS ) ),
 				),
 			);
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Fixes the issue with nps survey appearing in new installs when the theme is downloaded programmatically.

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-fse/issues/116.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->