### PR TITLE
Adds color slugs compatibility

### DIFF
--- a/assets/css/src/common/_generic.scss
+++ b/assets/css/src/common/_generic.scss
@@ -64,9 +64,26 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 /*
  * Color slugs compatibility between Raft and TI FSE themes
  */
-.has-ti-bg-inv-background-color {background-color:var(--wp--preset--color--raft-bg-inv);}
-.has-ti-bg-background-color {background-color:var(--wp--preset--color--raft-bg);}
-.has-ti-bg-alt-background-color {background-color:var(--wp--preset--color--raft-bg-alt);}
-.has-ti-fg-alt-color  {color:var(--wp--preset--color--raft-fg-alt);}
-.has-ti-accent-background-color {background-color:var(--wp--preset--color--raft-accent);}
-.has-ti-accent-secondary-background-color {background-color:var(--wp--preset--color--raft-accent-secondary);}
+.has-ti-bg-inv-background-color {
+	background-color: var(--wp--preset--color--raft-bg-inv);
+}
+
+.has-ti-bg-background-color {
+	background-color: var(--wp--preset--color--raft-bg);
+}
+
+.has-ti-bg-alt-background-color {
+	background-color: var(--wp--preset--color--raft-bg-alt);
+}
+
+.has-ti-fg-alt-color {
+	color: var(--wp--preset--color--raft-fg-alt);
+}
+
+.has-ti-accent-background-color {
+	background-color: var(--wp--preset--color--raft-accent);
+}
+
+.has-ti-accent-secondary-background-color {
+	background-color: var(--wp--preset--color--raft-accent-secondary);
+}

--- a/assets/css/src/common/_generic.scss
+++ b/assets/css/src/common/_generic.scss
@@ -60,3 +60,13 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 	margin-right: calc(-1 * var(--wp--custom--spacing--outer)) !important;
 	width: unset;
 }
+
+/*
+ * Color slugs compatibility between Raft and TI FSE themes
+ */
+.has-ti-bg-inv-background-color {background-color:var(--wp--preset--color--raft-bg-inv);}
+.has-ti-bg-background-color {background-color:var(--wp--preset--color--raft-bg);}
+.has-ti-bg-alt-background-color {background-color:var(--wp--preset--color--raft-bg-alt);}
+.has-ti-fg-alt-color  {color:var(--wp--preset--color--raft-fg-alt);}
+.has-ti-accent-background-color {background-color:var(--wp--preset--color--raft-accent);}
+.has-ti-accent-secondary-background-color {background-color:var(--wp--preset--color--raft-accent-secondary);}


### PR DESCRIPTION
Added the css fallback at the end of the file.

```
.has-ti-bg-inv-background-color {background-color:var(--wp--preset--color--raft-bg-inv);}
.has-ti-bg-background-color {background-color:var(--wp--preset--color--raft-bg);}
.has-ti-bg-alt-background-color {background-color:var(--wp--preset--color--raft-bg-alt);}
.has-ti-fg-alt-color  {color:var(--wp--preset--color--raft-fg-alt);}
.has-ti-accent-background-color {background-color:var(--wp--preset--color--raft-accent);}
.has-ti-accent-secondary-background-color {background-color:var(--wp--preset--color--raft-accent-secondary);}
```

This should apply the styles on both the frontend and the editor. I will test it.

<!-- Issues that this pull request closes. -->
Closes #119 .
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->