### PR TITLE
Removed duplicate title tag

### DIFF
--- a/inc/Core.php
+++ b/inc/Core.php
@@ -155,6 +155,13 @@ class Core {
 			)
 		);
 
+		// WP < 5.9, wp_head() does NOT auto-output <title>, so we MUST declare title-tag support.
+		// WP >= 5.9, wp-includes/template-canvas.php calls wp_head() which already handles <title> natively.
+		// Adding title-tag support on top causes a second <title> injection when Yoast (or any SEO plugin using wp_title filters) is active.
+		if ( version_compare( $GLOBALS['wp_version'], '5.9', '<' ) ) {
+			add_theme_support( 'title-tag' );
+		}
+
 		remove_theme_support( 'core-block-patterns' );
 
 		register_nav_menus( array( 'primary' => esc_html__( 'Primary Menu', 'raft' ) ) );

--- a/inc/Core.php
+++ b/inc/Core.php
@@ -71,7 +71,6 @@ class Core {
 		add_theme_support( 'starter-content', $starter_content->get() );
 		add_theme_support( 'wp-block-styles' );
 		add_theme_support( 'automatic-feed-links' );
-		add_theme_support( 'title-tag' );
 		add_theme_support( 'post-thumbnails' );
 		add_theme_support( 'editor-styles' );
 		add_theme_support(


### PR DESCRIPTION
### Summary
Removed the `title-tag` support as WordPress uses the template canvas, which already calls `wp_head()` and adds the title tag in the header.

Closes https://github.com/Codeinwp/raft/issues/137